### PR TITLE
Restore morph functionality with area fills and randomisers

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,17 @@
   .col{display:grid;grid-template-columns:1fr 1fr;gap:8px}
   button{background:#d8efe3;border:none;color:#10281f;padding:9px 12px;border-radius:10px;font-weight:700;cursor:pointer}
   button.secondary{background:#103126;color:#d8efe3;border:1px solid #1a5a47}
+  button.secondary.active{background:#1e5a45;color:#d8efe3;border-color:#2c8b6b}
   input[type=file]{display:none}
   label.file{padding:9px 12px;border:1px dashed #2a7a61;border-radius:10px;color:#c7eee1;cursor:pointer}
   .tiny{font-size:11px;color:#bde7da}
   .list{flex:1;overflow:auto;border:1px solid #1a5a47;border-radius:10px;padding:8px;background:#0c2a21;min-height:160px;max-height:260px}
   .badge{display:inline-block;padding:3px 7px;border-radius:8px;background:#0e372b;margin:3px 3px 0 0;border:1px solid #1a5a47;cursor:pointer}
+  .area-scroll{border:1px solid #1a5a47;border-radius:10px;padding:8px;background:#0c2a21;max-height:180px;overflow:auto;margin-top:6px}
+  .area-entry{display:flex;align-items:center;justify-content:space-between;gap:8px;margin:4px 0;padding:4px 6px;background:#0b241c;border-radius:8px}
+  .area-chip{display:flex;align-items:center;gap:6px;color:#cbeee2;font-size:11px}
+  .area-swatch{width:18px;height:18px;border-radius:6px;border:1px solid #1a5a47}
+  .area-entry button{padding:4px 8px;font-size:11px;border-radius:8px}
   canvas{width:100%;height:100%;display:block;border:1px solid var(--line);border-radius:14px;background:#0f2f24}
   .hud{position:fixed;right:10px;bottom:10px;background:#0c2a21cc;border:1px solid #1a5a47;border-radius:10px;padding:8px 10px;font-size:11px;color:#cbeee2;max-width:50ch}
   .toggle{display:flex;align-items:center;gap:6px}
@@ -157,6 +163,26 @@
       <input id="shadeJitter" type="range" min="0" max="2" step="0.05" value="0.6">
       <span class="tiny" id="shadeJitterLbl">0.60×</span>
     </div>
+    <div class="row">
+      <button id="randomiseShade" class="secondary">Randomise shading</button>
+      <button id="randomiseAnim" class="secondary">Randomise animation</button>
+    </div>
+
+    <h2>Area fills</h2>
+    <div class="row toggle">
+      <input type="checkbox" id="areaMode">
+      <label for="areaMode" class="tiny">Enable area selection</label>
+    </div>
+    <div class="row">
+      <label class="tiny">Colour</label><input id="areaColor" type="color" value="#3bd6ff">
+      <label class="tiny">Opacity</label><input id="areaOpacity" type="range" min="0.05" max="0.9" step="0.05" value="0.35">
+      <span class="tiny" id="areaOpacityLbl">0.35</span>
+    </div>
+    <div class="row">
+      <button id="areaRandom" class="secondary">Randomise fills</button>
+      <button id="areaClear" class="secondary">Clear fills</button>
+    </div>
+    <div id="areaList" class="area-scroll"></div>
 
     <h2>Animation</h2>
     <div class="row toggle">
@@ -226,17 +252,22 @@
 
 <script>
 const cv=document.getElementById('cv'), ctx=cv.getContext('2d');
+cv.style.touchAction='none';
 const hud=document.getElementById('hud');
 let W=0,H=0,DPR=1, FIXED=null;
 const gridOverlayCache={path:null, width:0, height:0, mode:'none', anchorVersion:-1, colsVersion:-1, rows:-1};
 const shadeCache={canvas:null, ctx:null, width:0, height:0, cover:-1, style:'', thickness:0, jitter:0, opacity:0, seed:0, color:''};
 const chalkState={count:0, passes:3, jitter:null, radius:null, updateCursor:0};
+let areaUiReady=false;
 function resize(){
   DPR=window.devicePixelRatio||1;
   if(FIXED){ W=FIXED.w; H=FIXED.h; }
   else { const b=cv.getBoundingClientRect(); W=Math.round(b.width*DPR); H=Math.round(b.height*DPR); }
   cv.width=W; cv.height=H;
   invalidateOverlay();
+  ensureAreaCanvas();
+  markAreaDirty();
+  if(areaUiReady) renderAreaList();
 }
 resize(); addEventListener('resize', ()=>{ if(!FIXED) { resize(); safeRebuild(); }});
 
@@ -266,6 +297,15 @@ const ui={
   shadeOpacityLbl:document.getElementById('shadeOpacityLbl'),
   shadeJitter:document.getElementById('shadeJitter'),
   shadeJitterLbl:document.getElementById('shadeJitterLbl'),
+  randomiseShade:document.getElementById('randomiseShade'),
+  randomiseAnim:document.getElementById('randomiseAnim'),
+  areaMode:document.getElementById('areaMode'),
+  areaColor:document.getElementById('areaColor'),
+  areaOpacity:document.getElementById('areaOpacity'),
+  areaOpacityLbl:document.getElementById('areaOpacityLbl'),
+  areaList:document.getElementById('areaList'),
+  areaRandom:document.getElementById('areaRandom'),
+  areaClear:document.getElementById('areaClear'),
   flowCurve:document.getElementById('flowCurve'),
   wander:document.getElementById('wander'),
   wanderLbl:document.getElementById('wanderLbl'),
@@ -1360,6 +1400,262 @@ function gotoShape(i){
 
 function renderList(){ ui.list.innerHTML=''; shapeNames.forEach((n,idx)=>{ const b=document.createElement('span'); b.textContent=(idx+1)+'. '+n; b.className='badge'; b.onclick=()=>gotoShape(idx); ui.list.appendChild(b); }); }
 
+const areaLayer={
+  areas:[],
+  nextId:1,
+  dirty:true,
+  canvas:document.createElement('canvas'),
+  ctx:null,
+  preview:null,
+  drawing:false,
+  start:null
+};
+areaLayer.ctx=areaLayer.canvas.getContext('2d');
+
+function ensureAreaCanvas(){
+  const w=Math.max(1,W||cv.width||1);
+  const h=Math.max(1,H||cv.height||1);
+  if(areaLayer.canvas.width!==w || areaLayer.canvas.height!==h){
+    areaLayer.canvas.width=w;
+    areaLayer.canvas.height=h;
+    areaLayer.dirty=true;
+  }
+}
+function markAreaDirty(){ areaLayer.dirty=true; }
+function rebuildAreaOverlay(){
+  ensureAreaCanvas();
+  const ctx=areaLayer.ctx;
+  if(!ctx) return;
+  ctx.clearRect(0,0,areaLayer.canvas.width, areaLayer.canvas.height);
+  const baseW=areaLayer.canvas.width;
+  const baseH=areaLayer.canvas.height;
+  for(const area of areaLayer.areas){
+    if(!Number.isFinite(area.nx) || !Number.isFinite(area.ny)) continue;
+    const x=Math.max(0, area.nx*baseW);
+    const y=Math.max(0, area.ny*baseH);
+    const w=Math.max(1, area.nw*baseW);
+    const h=Math.max(1, area.nh*baseH);
+    ctx.fillStyle=colorWithAlpha(area.color || '#ffffff', area.opacity||0.3);
+    ctx.fillRect(x, y, w, h);
+  }
+  areaLayer.dirty=false;
+}
+function pointerToCanvas(e){
+  const rect=cv.getBoundingClientRect();
+  const scaleX = rect.width>0 ? (W/rect.width) : 1;
+  const scaleY = rect.height>0 ? (H/rect.height) : 1;
+  return {
+    x: (e.clientX-rect.left)*scaleX,
+    y: (e.clientY-rect.top)*scaleY
+  };
+}
+function describeArea(area){
+  const w=Math.round(area.nw*(W||cv.width||0));
+  const h=Math.round(area.nh*(H||cv.height||0));
+  return `${w}×${h}`;
+}
+function renderAreaList(){
+  if(!ui.areaList) return;
+  ui.areaList.innerHTML='';
+  if(!areaLayer.areas.length){
+    const empty=document.createElement('div');
+    empty.className='tiny';
+    empty.textContent=ui.areaMode && ui.areaMode.checked ? 'Drag on the canvas to add fills.' : 'Enable area selection to add fills.';
+    ui.areaList.appendChild(empty);
+    return;
+  }
+  for(const area of areaLayer.areas){
+    const row=document.createElement('div');
+    row.className='area-entry';
+    const chip=document.createElement('div');
+    chip.className='area-chip';
+    const swatch=document.createElement('span');
+    swatch.className='area-swatch';
+    swatch.style.background=area.color;
+    swatch.style.opacity=Math.max(0.05, Math.min(1, area.opacity));
+    chip.appendChild(swatch);
+    const label=document.createElement('span');
+    label.textContent=`${describeArea(area)} • ${Math.round((area.opacity||0)*100)}%`;
+    chip.appendChild(label);
+    row.appendChild(chip);
+    const btn=document.createElement('button');
+    btn.className='secondary';
+    btn.textContent='Remove';
+    btn.onclick=()=>{
+      areaLayer.areas=areaLayer.areas.filter(a=>a.id!==area.id);
+      markAreaDirty();
+      renderAreaList();
+      draw();
+    };
+    row.appendChild(btn);
+    ui.areaList.appendChild(row);
+  }
+}
+
+function clampOpacity(v){
+  const num=parseFloat(v);
+  if(!Number.isFinite(num)) return 0.35;
+  return Math.max(0.05, Math.min(0.9, num));
+}
+function commitArea(rect){
+  if(!rect) return;
+  const color=ui.areaColor?ui.areaColor.value:'#3bd6ff';
+  const opacity=clampOpacity(ui.areaOpacity?ui.areaOpacity.value:0.35);
+  const baseW=Math.max(1, W||cv.width||1);
+  const baseH=Math.max(1, H||cv.height||1);
+  const clampedX=Math.max(0, Math.min(baseW, rect.x));
+  const clampedY=Math.max(0, Math.min(baseH, rect.y));
+  const clampedW=Math.max(0, Math.min(baseW-clampedX, rect.w));
+  const clampedH=Math.max(0, Math.min(baseH-clampedY, rect.h));
+  if(clampedW<6 || clampedH<6) return;
+  areaLayer.areas.push({
+    id:areaLayer.nextId++,
+    nx:Math.max(0, Math.min(1, clampedX/baseW)),
+    ny:Math.max(0, Math.min(1, clampedY/baseH)),
+    nw:Math.max(0, Math.min(1, clampedW/baseW)),
+    nh:Math.max(0, Math.min(1, clampedH/baseH)),
+    color,
+    opacity
+  });
+  markAreaDirty();
+  renderAreaList();
+}
+function clearAreaPreview(){ areaLayer.preview=null; }
+function handleAreaPointerDown(e){
+  if(!ui.areaMode || !ui.areaMode.checked) return;
+  if(e.button!==0 && e.pointerType!=='touch' && e.pointerType!=='pen') return;
+  e.preventDefault();
+  const baseW=Math.max(1, W||cv.width||1);
+  const baseH=Math.max(1, H||cv.height||1);
+  const pos=pointerToCanvas(e);
+  const startX=Math.max(0, Math.min(baseW, pos.x));
+  const startY=Math.max(0, Math.min(baseH, pos.y));
+  areaLayer.drawing=true;
+  areaLayer.start={x:startX,y:startY};
+  areaLayer.preview={x:startX,y:startY,w:0,h:0};
+  if(cv.setPointerCapture){ try{ cv.setPointerCapture(e.pointerId); }catch(err){} }
+}
+function handleAreaPointerMove(e){
+  if(!areaLayer.drawing) return;
+  e.preventDefault();
+  const baseW=Math.max(1, W||cv.width||1);
+  const baseH=Math.max(1, H||cv.height||1);
+  const pos=pointerToCanvas(e);
+  const curX=Math.max(0, Math.min(baseW, pos.x));
+  const curY=Math.max(0, Math.min(baseH, pos.y));
+  const startX=Math.max(0, Math.min(baseW, areaLayer.start.x));
+  const startY=Math.max(0, Math.min(baseH, areaLayer.start.y));
+  const x=Math.min(curX, startX);
+  const y=Math.min(curY, startY);
+  const w=Math.abs(curX-startX);
+  const h=Math.abs(curY-startY);
+  areaLayer.preview={x,y,w,h};
+  draw();
+}
+function handleAreaPointerUp(e){
+  if(!areaLayer.drawing) return;
+  e.preventDefault();
+  if(cv.releasePointerCapture){ try{ cv.releasePointerCapture(e.pointerId); }catch(err){} }
+  const rect=areaLayer.preview;
+  areaLayer.drawing=false;
+  areaLayer.start=null;
+  clearAreaPreview();
+  commitArea(rect);
+  draw();
+}
+function handleAreaPointerCancel(e){
+  if(!areaLayer.drawing) return;
+  if(cv.releasePointerCapture){ try{ cv.releasePointerCapture(e.pointerId); }catch(err){} }
+  areaLayer.drawing=false;
+  areaLayer.start=null;
+  clearAreaPreview();
+  draw();
+}
+function drawAreaOverlay(){
+  if(!areaLayer.areas.length) return;
+  ensureAreaCanvas();
+  if(areaLayer.dirty) rebuildAreaOverlay();
+  if(!areaLayer.canvas.width || !areaLayer.canvas.height) return;
+  ctx.save();
+  ctx.globalCompositeOperation='source-over';
+  ctx.drawImage(areaLayer.canvas,0,0, W, H);
+  ctx.restore();
+}
+function drawAreaPreview(){
+  if(!areaLayer.preview) return;
+  const rect=areaLayer.preview;
+  ctx.save();
+  ctx.strokeStyle=colorWithAlpha(ui.areaColor?ui.areaColor.value:'#3bd6ff',0.9);
+  ctx.fillStyle=colorWithAlpha(ui.areaColor?ui.areaColor.value:'#3bd6ff',0.15);
+  ctx.lineWidth=1.2*DPR;
+  ctx.setLineDash([6*DPR,4*DPR]);
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.restore();
+}
+function randomAreaColor(){
+  const h=Math.random()*360;
+  const s=0.38+Math.random()*0.3;
+  const l=0.35+Math.random()*0.3;
+  return hslToHex(h,s,l);
+}
+function randomiseShadingControls(){
+  if(ui.shadeStyle){ ui.shadeStyle.value=Math.random()>0.45?'segments':'ribbons'; }
+  if(ui.shadeThickness){
+    const v=(0.6+Math.random()*4.4).toFixed(2);
+    ui.shadeThickness.value=v;
+  }
+  if(ui.shadeOpacity){
+    const v=(0.10+Math.random()*0.6).toFixed(2);
+    ui.shadeOpacity.value=v;
+  }
+  if(ui.shadeJitter){
+    const v=(Math.random()*2).toFixed(2);
+    ui.shadeJitter.value=v;
+  }
+  if(ui.colorShade){ ui.colorShade.value=randomAreaColor(); }
+  updateShadeThickness();
+  updateShadeOpacity();
+  updateShadeJitter();
+  applyPalette();
+  resetEffects();
+  draw();
+}
+function randomiseAnimationControls(){
+  if(ui.flowCurve){
+    const opts=['easeInOut','easeIn','easeOut','cosine','bounce'];
+    ui.flowCurve.value=opts[Math.floor(Math.random()*opts.length)];
+  }
+  if(ui.wander){
+    const val=(Math.random()*0.8).toFixed(2);
+    ui.wander.value=val;
+    if(ui.wanderLbl) ui.wanderLbl.textContent=`${Math.round(parseFloat(val)*100)}%`;
+  }
+  if(ui.pulse){ ui.pulse.checked=Math.random()>0.5; }
+  if(ui.trail){ ui.trail.checked=Math.random()>0.65; }
+  if(ui.durErase){ ui.durErase.value=Math.round(300+Math.random()*900); }
+  if(ui.durMove){ ui.durMove.value=Math.round(900+Math.random()*1400); }
+  if(ui.durDraw){ ui.durDraw.value=Math.round(900+Math.random()*1600); }
+  updateDurations();
+  resetEffects();
+  gotoShape(mode);
+  draw();
+}
+function randomiseAreaFills(){
+  if(!areaLayer.areas.length){
+    if(ui.areaColor) ui.areaColor.value=randomAreaColor();
+    if(areaLayer.preview){ draw(); }
+    return;
+  }
+  for(const area of areaLayer.areas){
+    area.color=randomAreaColor();
+    area.opacity=clampOpacity(0.2+Math.random()*0.6);
+  }
+  markAreaDirty();
+  renderAreaList();
+  draw();
+}
+
 let lastSceneIndex=-1;
 function applyCreativeScene(index){
   const scene=creativeScenes[index];
@@ -1409,6 +1705,23 @@ ui.shadeOpacity.oninput=()=>{ updateShadeOpacity(); draw(); };
 ui.shadeOpacity.onchange=()=>{ updateShadeOpacity(); resetEffects(); draw(); };
 ui.shadeJitter.oninput=()=>{ updateShadeJitter(); draw(); };
 ui.shadeJitter.onchange=()=>{ updateShadeJitter(); resetEffects(); draw(); };
+if(ui.randomiseShade){ ui.randomiseShade.addEventListener('click', randomiseShadingControls); }
+if(ui.randomiseAnim){ ui.randomiseAnim.addEventListener('click', randomiseAnimationControls); }
+const updateAreaOpacityLabel=()=>{ if(ui.areaOpacity && ui.areaOpacityLbl){ ui.areaOpacityLbl.textContent=clampOpacity(ui.areaOpacity.value).toFixed(2); } };
+if(ui.areaOpacity){
+  ui.areaOpacity.addEventListener('input', ()=>{ updateAreaOpacityLabel(); if(areaLayer.preview){ draw(); } });
+  ui.areaOpacity.addEventListener('change', updateAreaOpacityLabel);
+}
+if(ui.areaColor){ ui.areaColor.addEventListener('input', ()=>{ if(areaLayer.preview){ draw(); } }); }
+if(ui.areaRandom){ ui.areaRandom.addEventListener('click', randomiseAreaFills); }
+if(ui.areaClear){ ui.areaClear.addEventListener('click', ()=>{ areaLayer.areas.length=0; markAreaDirty(); renderAreaList(); draw(); }); }
+if(ui.areaMode){
+  ui.areaMode.addEventListener('change', ()=>{
+    if(!ui.areaMode.checked && areaLayer.drawing){ areaLayer.drawing=false; areaLayer.start=null; clearAreaPreview(); }
+    renderAreaList();
+    draw();
+  });
+}
 ['colorDots','colorShade','colorGrid','colorBgInner','colorBgOuter','colorGuide'].forEach(key=>{
   if(ui[key]){
     ui[key].addEventListener('input', applyPalette);
@@ -1431,7 +1744,16 @@ if(ui.restorePalette){
 updateShadeThickness();
 updateShadeOpacity();
 updateShadeJitter();
+updateAreaOpacityLabel();
+areaUiReady=true;
+renderAreaList();
 applyPalette();
+
+cv.addEventListener('pointerdown', handleAreaPointerDown);
+cv.addEventListener('pointermove', handleAreaPointerMove);
+cv.addEventListener('pointerup', handleAreaPointerUp);
+cv.addEventListener('pointercancel', handleAreaPointerCancel);
+cv.addEventListener('pointerleave', handleAreaPointerCancel);
 
 // controls
 ui.cycle.onclick=()=>gotoShape(mode+1);
@@ -1772,7 +2094,7 @@ function drawTraceOverlay(r){
   ctx.restore();
 }
 
-function draw(){ drawBg(); drawGridOverlay(); const r=parseFloat(ui.size.value)*DPR; drawShadeOverlay(r); const useChalk=ui.chalk.checked;
+function draw(){ drawBg(); drawGridOverlay(); const r=parseFloat(ui.size.value)*DPR; drawShadeOverlay(r); drawAreaOverlay(); const useChalk=ui.chalk.checked;
   if(useChalk){
     syncChalkState();
     updateChalkState(lastDt||16);
@@ -1845,6 +2167,7 @@ function draw(){ drawBg(); drawGridOverlay(); const r=parseFloat(ui.size.value)*
     }
   }
   ctx.shadowBlur=0; ctx.globalAlpha=1;
+  drawAreaPreview();
   drawTraceOverlay(r);
   const phase=!trans.active?'idle':(trans.t<trans.t1?'erase':(trans.t<trans.t2?'move':(trans.t<trans.t3?'reveal':'hold')));
   const gridState = (!ui.useGrid.checked || !(grid.cols&&grid.cols.length)) ? 'off' : (grid.cols.length===1 ? 'centreline' : ui.snapMode.value);

--- a/index.html
+++ b/index.html
@@ -259,6 +259,7 @@ const gridOverlayCache={path:null, width:0, height:0, mode:'none', anchorVersion
 const shadeCache={canvas:null, ctx:null, width:0, height:0, cover:-1, style:'', thickness:0, jitter:0, opacity:0, seed:0, color:''};
 const chalkState={count:0, passes:3, jitter:null, radius:null, updateCursor:0};
 let areaUiReady=false;
+let areaLayer;
 function resize(){
   DPR=window.devicePixelRatio||1;
   if(FIXED){ W=FIXED.w; H=FIXED.h; }
@@ -271,50 +272,86 @@ function resize(){
 }
 resize(); addEventListener('resize', ()=>{ if(!FIXED) { resize(); safeRebuild(); }});
 
+const el=id=>document.getElementById(id);
 const ui={
-  count:dotCount,countLbl:dotCountLbl,speed,speedLbl,size,sizeLbl,
-  svg:svgInput,add:addFromSVG,file:document.getElementById('file'),
-  list:shapeList,cycle, pause, selfTest, chalk:document.getElementById('chalk'),
-  drawOn:drawOn, showGuide:showGuide, durErase, durMove, durDraw,
-  fit:fitMode, pad:pad, res:res, rec:rec, stopRec:stopRec,
-  useGrid, showGrid, snapMode, snapAmt, snapAmtLbl,
-  gridRows, gridCols, gridFile, applyGrid, clearGrid,
-  gridFromInput:document.getElementById('gridFromInput'),
-  gridFromShape:document.getElementById('gridFromShape'),
-  lockGrid, traceOutline, shadeFill, traceMs, shadeMs,
-  colorDots:document.getElementById('colorDots'),
-  colorShade:document.getElementById('colorShade'),
-  colorGrid:document.getElementById('colorGrid'),
-  colorBgInner:document.getElementById('colorBgInner'),
-  colorBgOuter:document.getElementById('colorBgOuter'),
-  colorGuide:document.getElementById('colorGuide'),
-  shufflePalette:document.getElementById('shufflePalette'),
-  restorePalette:document.getElementById('restorePalette'),
-  shadeStyle:document.getElementById('shadeStyle'),
-  shadeThickness:document.getElementById('shadeThickness'),
-  shadeThicknessLbl:document.getElementById('shadeThicknessLbl'),
-  shadeOpacity:document.getElementById('shadeOpacity'),
-  shadeOpacityLbl:document.getElementById('shadeOpacityLbl'),
-  shadeJitter:document.getElementById('shadeJitter'),
-  shadeJitterLbl:document.getElementById('shadeJitterLbl'),
-  randomiseShade:document.getElementById('randomiseShade'),
-  randomiseAnim:document.getElementById('randomiseAnim'),
-  areaMode:document.getElementById('areaMode'),
-  areaColor:document.getElementById('areaColor'),
-  areaOpacity:document.getElementById('areaOpacity'),
-  areaOpacityLbl:document.getElementById('areaOpacityLbl'),
-  areaList:document.getElementById('areaList'),
-  areaRandom:document.getElementById('areaRandom'),
-  areaClear:document.getElementById('areaClear'),
-  flowCurve:document.getElementById('flowCurve'),
-  wander:document.getElementById('wander'),
-  wanderLbl:document.getElementById('wanderLbl'),
-  pulse:document.getElementById('pulse'),
-  trail:document.getElementById('trail'),
-  sceneInspire:document.getElementById('sceneInspire'),
-  sceneLabel:document.getElementById('sceneLabel'),
-  stagger, lag, gridWarn: document.getElementById('gridWarn')
+  count:el('dotCount'),
+  countLbl:el('dotCountLbl'),
+  speed:el('speed'),
+  speedLbl:el('speedLbl'),
+  size:el('size'),
+  sizeLbl:el('sizeLbl'),
+  svg:el('svgInput'),
+  add:el('addFromSVG'),
+  file:el('file'),
+  list:el('shapeList'),
+  cycle:el('cycle'),
+  pause:el('pause'),
+  selfTest:el('selfTest'),
+  chalk:el('chalk'),
+  drawOn:el('drawOn'),
+  showGuide:el('showGuide'),
+  durErase:el('durErase'),
+  durMove:el('durMove'),
+  durDraw:el('durDraw'),
+  fit:el('fitMode'),
+  pad:el('pad'),
+  res:el('res'),
+  rec:el('rec'),
+  stopRec:el('stopRec'),
+  useGrid:el('useGrid'),
+  showGrid:el('showGrid'),
+  snapMode:el('snapMode'),
+  snapAmt:el('snapAmt'),
+  snapAmtLbl:el('snapAmtLbl'),
+  gridRows:el('gridRows'),
+  gridCols:el('gridCols'),
+  gridFile:el('gridFile'),
+  applyGrid:el('applyGrid'),
+  clearGrid:el('clearGrid'),
+  gridFromInput:el('gridFromInput'),
+  gridFromShape:el('gridFromShape'),
+  lockGrid:el('lockGrid'),
+  traceOutline:el('traceOutline'),
+  shadeFill:el('shadeFill'),
+  traceMs:el('traceMs'),
+  shadeMs:el('shadeMs'),
+  colorDots:el('colorDots'),
+  colorShade:el('colorShade'),
+  colorGrid:el('colorGrid'),
+  colorBgInner:el('colorBgInner'),
+  colorBgOuter:el('colorBgOuter'),
+  colorGuide:el('colorGuide'),
+  shufflePalette:el('shufflePalette'),
+  restorePalette:el('restorePalette'),
+  shadeStyle:el('shadeStyle'),
+  shadeThickness:el('shadeThickness'),
+  shadeThicknessLbl:el('shadeThicknessLbl'),
+  shadeOpacity:el('shadeOpacity'),
+  shadeOpacityLbl:el('shadeOpacityLbl'),
+  shadeJitter:el('shadeJitter'),
+  shadeJitterLbl:el('shadeJitterLbl'),
+  randomiseShade:el('randomiseShade'),
+  randomiseAnim:el('randomiseAnim'),
+  areaMode:el('areaMode'),
+  areaColor:el('areaColor'),
+  areaOpacity:el('areaOpacity'),
+  areaOpacityLbl:el('areaOpacityLbl'),
+  areaList:el('areaList'),
+  areaRandom:el('areaRandom'),
+  areaClear:el('areaClear'),
+  flowCurve:el('flowCurve'),
+  wander:el('wander'),
+  wanderLbl:el('wanderLbl'),
+  pulse:el('pulse'),
+  trail:el('trail'),
+  sceneInspire:el('sceneInspire'),
+  sceneLabel:el('sceneLabel'),
+  stagger:el('stagger'),
+  lag:el('lag'),
+  gridWarn:el('gridWarn')
 };
+const missingUi=Object.entries(ui).filter(([,el])=>!el).map(([key])=>key);
+if(missingUi.length){ console.warn('Missing UI controls:', missingUi.join(', ')); }
 const eases={
   easeInOut:t=>t<0.5?2*t*t:1-(((-2*t+2)**2)/2),
   easeIn:t=>t*t,
@@ -968,7 +1005,7 @@ const creativeScenes=[
 ];
 
 let shapes=[]; let shapeNames=presets.map(p=>p.name); let shapeGroups=[];
-let mode=0, paused=false, speedMul=parseFloat(speed.value), nowMs=0, previousTrailState=false;
+let mode=0, paused=false, speedMul=parseFloat((ui.speed&&ui.speed.value)||'1')||1, nowMs=0, previousTrailState=false;
 let dots=[];
 let last=0, lastDt=16;
 
@@ -1055,29 +1092,42 @@ const jitterMemo=new Map();
 function invalidateOverlay(){ gridOverlayCache.path=null; }
 function isGridLocked(){ return !!(ui.lockGrid && ui.lockGrid.checked && grid.anchorBase.length); }
 function showLockWarning(){ if(ui.gridWarn){ ui.gridWarn.textContent='Grid locked to Milton Court. Disable lock to edit grid.'; ui.gridWarn.style.display='block'; } }
-ui.snapAmt.oninput=()=>ui.snapAmtLbl.textContent=parseFloat(ui.snapAmt.value).toFixed(2);
-ui.gridFile.addEventListener('change', async e=>{ const f=e.target.files[0]; if(!f) return; const txt=await f.text(); autoColsFromSVG(txt); });
-ui.applyGrid.onclick=()=>{ applyGridFromCSV(ui.gridCols.value); };
-ui.clearGrid.onclick=()=>{
+if(ui.snapAmt && ui.snapAmtLbl){
+  ui.snapAmt.oninput=()=>ui.snapAmtLbl.textContent=parseFloat(ui.snapAmt.value).toFixed(2);
+}
+if(ui.gridFile){
+  ui.gridFile.addEventListener('change', async e=>{ const f=e.target.files[0]; if(!f) return; const txt=await f.text(); autoColsFromSVG(txt); });
+}
+if(ui.applyGrid){
+  ui.applyGrid.onclick=()=>{ applyGridFromCSV(ui.gridCols?ui.gridCols.value:''); };
+}
+if(ui.clearGrid){
+  ui.clearGrid.onclick=()=>{
   if(isGridLocked()){ showLockWarning(); return; }
   grid.cols=[];
   grid.colsVersion++;
   invalidateOverlay();
   setAnchorBase([]);
-  ui.gridCols.value='';
-  ui.gridWarn.style.display='none';
+    if(ui.gridCols) ui.gridCols.value='';
+    if(ui.gridWarn){ ui.gridWarn.style.display='none'; ui.gridWarn.textContent=''; }
   safeRebuild();
-};
-ui.gridFromInput.onclick = ()=>{
-  const raw = ui.svg.value.trim();
+  };
+}
+if(ui.gridFromInput){
+  ui.gridFromInput.onclick = ()=>{
+  const raw = ui.svg && typeof ui.svg.value==='string' ? ui.svg.value.trim() : '';
   if(!raw){
-    ui.gridWarn.textContent='Textbox is empty.'; ui.gridWarn.style.display='block'; return;
+    if(ui.gridWarn){ ui.gridWarn.textContent='Textbox is empty.'; ui.gridWarn.style.display='block'; }
+    return;
   }
   setGridFromSVGAligned(raw);
-};
-ui.gridFromShape.onclick = ()=>{
-  setGridFromCurrentShape();
-};
+  };
+}
+if(ui.gridFromShape){
+  ui.gridFromShape.onclick = ()=>{
+    setGridFromCurrentShape();
+  };
+}
 
 function applyGridFromCSV(csv){
   if(isGridLocked()){ showLockWarning(); return; }
@@ -1323,7 +1373,10 @@ function initDots(){
 }
 
 function rebuildTargets(){
-  N = parseInt(ui.count.value,10); ui.countLbl.textContent=N; updateDurations(); regenerateShapes();
+  N = parseInt(ui.count.value,10);
+  if(ui.countLbl) ui.countLbl.textContent=N;
+  updateDurations();
+  regenerateShapes();
   const rawTargets = ensureLength(shapes[mode]||[], N).map((p,i)=>({x:p.x,y:p.y,g:shapeGroups[mode]?shapeGroups[mode][i]:0}));
   const snapped = applyGridSnap(rawTargets);
   const S0 = sanitizePoints(snapped);
@@ -1400,7 +1453,7 @@ function gotoShape(i){
 
 function renderList(){ ui.list.innerHTML=''; shapeNames.forEach((n,idx)=>{ const b=document.createElement('span'); b.textContent=(idx+1)+'. '+n; b.className='badge'; b.onclick=()=>gotoShape(idx); ui.list.appendChild(b); }); }
 
-const areaLayer={
+areaLayer={
   areas:[],
   nextId:1,
   dirty:true,
@@ -1413,6 +1466,7 @@ const areaLayer={
 areaLayer.ctx=areaLayer.canvas.getContext('2d');
 
 function ensureAreaCanvas(){
+  if(!areaLayer) return;
   const w=Math.max(1,W||cv.width||1);
   const h=Math.max(1,H||cv.height||1);
   if(areaLayer.canvas.width!==w || areaLayer.canvas.height!==h){
@@ -1421,7 +1475,7 @@ function ensureAreaCanvas(){
     areaLayer.dirty=true;
   }
 }
-function markAreaDirty(){ areaLayer.dirty=true; }
+function markAreaDirty(){ if(!areaLayer) return; areaLayer.dirty=true; }
 function rebuildAreaOverlay(){
   ensureAreaCanvas();
   const ctx=areaLayer.ctx;
@@ -1678,33 +1732,33 @@ function inspireScene(){
 }
 
 // Add custom SVG
-ui.add.onclick=()=>{
-  const raw=ui.svg.value.trim();
-  if(!raw) return;
-  const name='Custom '+(shapeNames.length+1);
-  presets.push({name, fn:()=>sampleSVG(raw, N)});
-  shapeNames.push(name);
-  // set grid to match this SVG (aligned to current fit/pad/canvas)
-  setGridFromSVGAligned(raw);
-  ui.svg.value='';
-  regenerateShapes(); renderList();
-};
-ui.file.addEventListener('change', async e=>{ const f=e.target.files[0]; if(!f) return; const txt=await f.text(); ui.svg.value=txt; });
-ui.lockGrid.onchange=()=>{ if(!ui.lockGrid.checked && ui.gridWarn){ ui.gridWarn.style.display='none'; } resetEffects(); };
-ui.traceOutline.onchange=()=>{ resetEffects(); draw(); };
-ui.shadeFill.onchange=()=>{ resetEffects(); draw(); };
-ui.traceMs.onchange=()=>{ resetEffects(); draw(); };
-ui.shadeMs.onchange=()=>{ resetEffects(); draw(); };
-ui.shadeStyle.onchange=()=>{ resetEffects(); draw(); };
-const updateShadeThickness=()=>{ if(ui.shadeThicknessLbl){ ui.shadeThicknessLbl.textContent=`${parseFloat(ui.shadeThickness.value||0).toFixed(1)}px`; } };
-const updateShadeOpacity=()=>{ if(ui.shadeOpacityLbl){ ui.shadeOpacityLbl.textContent=parseFloat(ui.shadeOpacity.value||0).toFixed(2); } };
-const updateShadeJitter=()=>{ if(ui.shadeJitterLbl){ ui.shadeJitterLbl.textContent=`${parseFloat(ui.shadeJitter.value||0).toFixed(2)}×`; } };
-ui.shadeThickness.oninput=()=>{ updateShadeThickness(); draw(); };
-ui.shadeThickness.onchange=()=>{ updateShadeThickness(); resetEffects(); draw(); };
-ui.shadeOpacity.oninput=()=>{ updateShadeOpacity(); draw(); };
-ui.shadeOpacity.onchange=()=>{ updateShadeOpacity(); resetEffects(); draw(); };
-ui.shadeJitter.oninput=()=>{ updateShadeJitter(); draw(); };
-ui.shadeJitter.onchange=()=>{ updateShadeJitter(); resetEffects(); draw(); };
+if(ui.add){
+  ui.add.onclick=()=>{
+    const raw=ui.svg && typeof ui.svg.value==='string' ? ui.svg.value.trim() : '';
+    if(!raw) return;
+    const name='Custom '+(shapeNames.length+1);
+    presets.push({name, fn:()=>sampleSVG(raw, N)});
+    shapeNames.push(name);
+    setGridFromSVGAligned(raw);
+    if(ui.svg) ui.svg.value='';
+    regenerateShapes(); renderList();
+  };
+}
+if(ui.file){
+  ui.file.addEventListener('change', async e=>{ const f=e.target.files[0]; if(!f) return; const txt=await f.text(); if(ui.svg) ui.svg.value=txt; });
+}
+if(ui.lockGrid){ ui.lockGrid.onchange=()=>{ if(!ui.lockGrid.checked && ui.gridWarn){ ui.gridWarn.style.display='none'; } resetEffects(); }; }
+if(ui.traceOutline){ ui.traceOutline.onchange=()=>{ resetEffects(); draw(); }; }
+if(ui.shadeFill){ ui.shadeFill.onchange=()=>{ resetEffects(); draw(); }; }
+if(ui.traceMs){ ui.traceMs.onchange=()=>{ resetEffects(); draw(); }; }
+if(ui.shadeMs){ ui.shadeMs.onchange=()=>{ resetEffects(); draw(); }; }
+if(ui.shadeStyle){ ui.shadeStyle.onchange=()=>{ resetEffects(); draw(); }; }
+const updateShadeThickness=()=>{ if(ui.shadeThickness && ui.shadeThicknessLbl){ ui.shadeThicknessLbl.textContent=`${parseFloat(ui.shadeThickness.value||0).toFixed(1)}px`; } };
+const updateShadeOpacity=()=>{ if(ui.shadeOpacity && ui.shadeOpacityLbl){ ui.shadeOpacityLbl.textContent=parseFloat(ui.shadeOpacity.value||0).toFixed(2); } };
+const updateShadeJitter=()=>{ if(ui.shadeJitter && ui.shadeJitterLbl){ ui.shadeJitterLbl.textContent=`${parseFloat(ui.shadeJitter.value||0).toFixed(2)}×`; } };
+if(ui.shadeThickness){ ui.shadeThickness.oninput=()=>{ updateShadeThickness(); draw(); }; ui.shadeThickness.onchange=()=>{ updateShadeThickness(); resetEffects(); draw(); }; }
+if(ui.shadeOpacity){ ui.shadeOpacity.oninput=()=>{ updateShadeOpacity(); draw(); }; ui.shadeOpacity.onchange=()=>{ updateShadeOpacity(); resetEffects(); draw(); }; }
+if(ui.shadeJitter){ ui.shadeJitter.oninput=()=>{ updateShadeJitter(); draw(); }; ui.shadeJitter.onchange=()=>{ updateShadeJitter(); resetEffects(); draw(); }; }
 if(ui.randomiseShade){ ui.randomiseShade.addEventListener('click', randomiseShadingControls); }
 if(ui.randomiseAnim){ ui.randomiseAnim.addEventListener('click', randomiseAnimationControls); }
 const updateAreaOpacityLabel=()=>{ if(ui.areaOpacity && ui.areaOpacityLbl){ ui.areaOpacityLbl.textContent=clampOpacity(ui.areaOpacity.value).toFixed(2); } };
@@ -1756,15 +1810,21 @@ cv.addEventListener('pointercancel', handleAreaPointerCancel);
 cv.addEventListener('pointerleave', handleAreaPointerCancel);
 
 // controls
-ui.cycle.onclick=()=>gotoShape(mode+1);
-ui.pause.onclick=()=>{paused=!paused; ui.pause.textContent=paused?'Play':'Pause';};
-ui.count.oninput=()=>ui.countLbl.textContent=ui.count.value; ui.count.onchange=safeRebuild;
-ui.speed.oninput=()=>{speedMul=parseFloat(ui.speed.value); ui.speedLbl.textContent=speedMul.toFixed(1)+'×';};
-ui.size.oninput=()=>ui.sizeLbl.textContent=ui.size.value;
-ui.durErase.onchange=updateDurations; ui.durMove.onchange=updateDurations; ui.durDraw.onchange=updateDurations;
-ui.fit.onchange=safeRebuild; ui.pad.onchange=safeRebuild;
-ui.useGrid.onchange=safeRebuild; ui.showGrid.onchange=()=>{}; ui.snapMode.onchange=safeRebuild; ui.gridRows.onchange=safeRebuild;
-ui.res.onchange=()=>{ const v=ui.res.value; if(v==='window'){ FIXED=null; } else { const [w,h]=v.split('x').map(Number); FIXED={w,h}; } resize(); safeRebuild(); };
+if(ui.cycle){ ui.cycle.onclick=()=>gotoShape(mode+1); }
+if(ui.pause){ ui.pause.onclick=()=>{ paused=!paused; ui.pause.textContent=paused?'Play':'Pause'; }; }
+if(ui.count){ ui.count.oninput=()=>{ if(ui.countLbl) ui.countLbl.textContent=ui.count.value; }; ui.count.onchange=safeRebuild; }
+if(ui.speed){ ui.speed.oninput=()=>{ speedMul=parseFloat(ui.speed.value); if(ui.speedLbl) ui.speedLbl.textContent=speedMul.toFixed(1)+'×'; }; }
+if(ui.size){ ui.size.oninput=()=>{ if(ui.sizeLbl) ui.sizeLbl.textContent=ui.size.value; }; }
+if(ui.durErase){ ui.durErase.onchange=updateDurations; }
+if(ui.durMove){ ui.durMove.onchange=updateDurations; }
+if(ui.durDraw){ ui.durDraw.onchange=updateDurations; }
+if(ui.fit){ ui.fit.onchange=safeRebuild; }
+if(ui.pad){ ui.pad.onchange=safeRebuild; }
+if(ui.useGrid){ ui.useGrid.onchange=safeRebuild; }
+if(ui.showGrid){ ui.showGrid.onchange=()=>{}; }
+if(ui.snapMode){ ui.snapMode.onchange=safeRebuild; }
+if(ui.gridRows){ ui.gridRows.onchange=safeRebuild; }
+if(ui.res){ ui.res.onchange=()=>{ const v=ui.res.value; if(v==='window'){ FIXED=null; } else { const [w,h]=v.split('x').map(Number); FIXED={w,h}; } resize(); safeRebuild(); }; }
 if(ui.flowCurve){
   ui.flowCurve.onchange=()=>{
     resetEffects();
@@ -1782,7 +1842,25 @@ if(ui.chalk){ ui.chalk.onchange=()=>{ syncChalkState(true); draw(); }; }
 if(ui.sceneInspire){ ui.sceneInspire.addEventListener('click', inspireScene); }
 
 // recording
-let mediaRecorder=null, recChunks=[]; ui.rec.onclick=()=>{ try{ const fps=50; const stream=cv.captureStream(fps); mediaRecorder=new MediaRecorder(stream,{mimeType:'video/webm;codecs=vp9'}); recChunks=[]; mediaRecorder.ondataavailable=e=>{ if(e.data.size>0) recChunks.push(e.data); }; mediaRecorder.onstop=()=>{ const blob=new Blob(recChunks,{type:'video/webm'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; const ts=new Date().toISOString().replace(/[:.]/g,'-'); a.download=`blueprint-morph-${W}x${H}-${fps}fps-${ts}.webm`; a.click(); URL.revokeObjectURL(url); }; mediaRecorder.start(); }catch(err){ alert('Recording not supported: '+err); } }; ui.stopRec.onclick=()=>{ if(mediaRecorder&&mediaRecorder.state!=='inactive'){ mediaRecorder.stop(); mediaRecorder=null; } };
+let mediaRecorder=null, recChunks=[];
+if(ui.rec){
+  ui.rec.onclick=()=>{
+    try{
+      const fps=50;
+      const stream=cv.captureStream(fps);
+      mediaRecorder=new MediaRecorder(stream,{mimeType:'video/webm;codecs=vp9'});
+      recChunks=[];
+      mediaRecorder.ondataavailable=e=>{ if(e.data.size>0) recChunks.push(e.data); };
+      mediaRecorder.onstop=()=>{ const blob=new Blob(recChunks,{type:'video/webm'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; const ts=new Date().toISOString().replace(/[:.]/g,'-'); a.download=`blueprint-morph-${W}x${H}-${fps}fps-${ts}.webm`; a.click(); URL.revokeObjectURL(url); };
+      mediaRecorder.start();
+    }catch(err){
+      alert('Recording not supported: '+err);
+    }
+  };
+}
+if(ui.stopRec){
+  ui.stopRec.onclick=()=>{ if(mediaRecorder&&mediaRecorder.state!=='inactive'){ mediaRecorder.stop(); mediaRecorder=null; } };
+}
 
 // keyboard
 addEventListener('keydown',e=>{ if(e.code==='Space'){e.preventDefault(); gotoShape(mode+1);} const n=+e.key; if(n>=1&&n<=9) gotoShape(n-1); });
@@ -2254,6 +2332,16 @@ function selfTests(){
   return results;
 }
 ui.selfTest.onclick=selfTests;
+window.morphApp={
+  get dots(){ return dots; },
+  get shapes(){ return shapes; },
+  get shapeNames(){ return shapeNames; },
+  get mode(){ return mode; },
+  get palette(){ return palette; },
+  gotoShape:(idx)=>gotoShape(idx),
+  applyPalette:()=>applyPalette(),
+  ui
+};
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reintroduce the working morph UI and add controls for area fills plus shading/animation randomisers
- implement a cached area-fill overlay with normalised coordinates, pointer drawing, and preview handling so selections persist across resizes
- wire the new tools into the render loop and UI events while keeping existing presets, grid logic, and smoothing intact

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68defaa7067c8327bbf9066940fd707f